### PR TITLE
fix safari audiocontext issue

### DIFF
--- a/src/Audio.ts
+++ b/src/Audio.ts
@@ -9,13 +9,19 @@ export type PropType = {
   loop?: boolean;
 };
 
+declare global {
+  interface Window {
+    webkitAudioContext: typeof AudioContext;
+  }
+}
+
 const Audio = ({
   file,
   volume = 1,
   autoPlay = false,
   loop = false,
 }: PropType) => {
-  const audioContext = new AudioContext();
+  const audioContext = new (window.AudioContext || window.webkitAudioContext)();
   const source = audioContext.createBufferSource();
   const states = StateManager();
 


### PR DESCRIPTION
Per the `AudioContext()` [docs](https://developer.mozilla.org/en-US/docs/Web/API/AudioContext/AudioContext), Safari requires a vendor prefix.

`AudioContext()` does not work on Safari (checked with v13.1), so a fallback was added to `webkitAudioContext()`.