### PR TITLE
docs: Fix simple typo, dependecies -> dependencies

### DIFF
--- a/demo/audio/README.md
+++ b/demo/audio/README.md
@@ -1,5 +1,5 @@
 # [ts-audio] sample
-For run the sample application, first install the dependecies:
+For run the sample application, first install the dependencies:
 
 ```sh
 $ npm install


### PR DESCRIPTION
There is a small typo in demo/audio/README.md.

Should read `dependencies` rather than `dependecies`.

