### PR TITLE
Implement `seek` method and precise `currentTime` tracking

### DIFF
--- a/demo/audio/package.json
+++ b/demo/audio/package.json
@@ -11,6 +11,6 @@
     "webpack-dev-server": "^5.2.1"
   },
   "dependencies": {
-    "ts-audio": "^0.7.4"
+    "ts-audio": "file:../.."
   }
 }

--- a/demo/audio/src/index.html
+++ b/demo/audio/src/index.html
@@ -1,14 +1,12 @@
 <!doctype html>
 <html>
   <head>
-    <title>
-      Demo - Audio
-    </title>
+    <title>Demo - Audio</title>
     <style>
       @import url('https://fonts.googleapis.com/css?family=Allerta&display=swap');
 
       * {
-        font-family: "Allerta", sans-serif;
+        font-family: 'Allerta', sans-serif;
         color: #212121;
       }
 
@@ -39,28 +37,49 @@
         background: #eee;
         padding: 20px;
         border-radius: 5px;
+        max-width: 420px;
+        width: min(90vw, 420px);
+        display: grid;
+        gap: 12px;
+      }
+
+      main > button {
+        padding: 8px 12px;
+      }
+
+      input[type='range'] {
+        width: 100%;
+        display: block;
+        appearance: none;
+        height: 8px;
+        background: #ddd;
+        border-radius: 4px;
+        outline: none;
+      }
+
+      /* Volume slider */
+      #volume {
+        accent-color: #00b894;
+      }
+
+      /* Duration slider */
+      #duration {
+        accent-color: #6c5ce7;
       }
     </style>
   </head>
   <body>
     <main>
-      <button type="button" id="bt-play">
-        Play
-      </button>
+      <button type="button" id="bt-play">Play</button>
 
-      <button type="button" id="bt-pause" disabled>
-        Pause
-      </button>
+      <button type="button" id="bt-pause" disabled>Pause</button>
 
-      <button type="button" id="bt-toggle">
-        Toggle
-      </button>
+      <button type="button" id="bt-toggle">Toggle</button>
 
-      <button type="button" id="bt-stop" disabled>
-        Stop
-      </button>
+      <button type="button" id="bt-stop" disabled>Stop</button>
 
-      <input type="range" min="0" max="100" value="50" id="range">
+      <input type="range" min="0" max="100" value="50" id="volume" />
+      <input type="range" min="0" value="0" step="0.01" id="duration" />
     </main>
   </body>
 </html>

--- a/demo/audio/src/index.js
+++ b/demo/audio/src/index.js
@@ -4,32 +4,51 @@ import song from './song.mp3'
 
 const getVolume = (element) => Number(element.value) / 100
 
-const range = document.getElementById('range')
+const volume = document.getElementById('volume')
+const duration = document.getElementById('duration')
 const buttonPlay = document.getElementById('bt-play')
 const buttonPause = document.getElementById('bt-pause')
 const buttonToggle = document.getElementById('bt-toggle')
 const buttonStop = document.getElementById('bt-stop')
+
 const audio = Audio({
   file: song,
   loop: true,
-  volume: getVolume(range),
+  volume: getVolume(volume),
   preload: true,
 })
 
+let intervalDurationId
+
 audio.on('end', () => {
+  console.log('end')
   buttonPlay.removeAttribute('disabled')
   buttonPause.setAttribute('disabled', 'disabled')
   buttonStop.setAttribute('disabled', 'disabled')
+  clearInterval(intervalDurationId)
 })
-
-console.log('audio ctx', audio.audioCtx)
 
 setTimeout(() => {
   audio.loop = false
 }, 2000)
 
-audio.on('ready', ({ data }) => console.log(data))
-audio.on('start', () => console.log('start'))
+audio.on('ready', ({ data }) => {
+  console.log('ready event data:', data)
+})
+
+audio.on('start', () => {
+  console.log('start')
+
+  if (intervalDurationId) {
+    clearInterval(intervalDurationId)
+  }
+
+  intervalDurationId = setInterval(() => {
+    duration.max = audio.duration
+    duration.value = audio.currentTime
+  }, 1000 / 60) // 60fps
+})
+
 audio.on('state', ({ data }) => console.log(data))
 
 buttonPlay.addEventListener('click', () => {
@@ -44,6 +63,7 @@ buttonPause.addEventListener('click', () => {
   buttonPause.setAttribute('disabled', 'disabled')
   buttonStop.setAttribute('disabled', 'disabled')
   buttonPlay.removeAttribute('disabled')
+  clearInterval(intervalDurationId)
 })
 
 buttonToggle.addEventListener('click', () => {
@@ -54,9 +74,14 @@ buttonStop.addEventListener('click', () => {
   audio.stop()
   buttonPause.setAttribute('disabled', 'disabled')
   buttonStop.setAttribute('disabled', 'disabled')
+  clearInterval(intervalDurationId)
 })
 
-range.addEventListener('change', (e) => {
+volume.addEventListener('change', (e) => {
   const volume = getVolume(e.target)
   audio.volume = volume
+})
+
+duration.addEventListener('input', (e) => {
+  audio.seek(Number(e.target.value))
 })

--- a/src/audio/Audio.ts
+++ b/src/audio/Audio.ts
@@ -330,6 +330,9 @@ export class AudioClass {
 
     // Stop current source if playing
     if (this._states.source && wasPlaying) {
+      // Temporarily remove onended handler to prevent false "end" events during seek
+      this._states.source.onended = null
+
       try {
         this._states.source.stop(0)
       } catch (error) {

--- a/src/audio/Audio.ts
+++ b/src/audio/Audio.ts
@@ -62,6 +62,10 @@ export class AudioClass {
   private _emitter: EventEmitter
   /** @private Event handler for managing event subscriptions */
   private _eventHandler: EventHandler
+  /** @private Track when playback started for currentTime calculation */
+  private _startTime: number = 0
+  /** @private Track pause position for accurate seeking */
+  private _pauseTime: number = 0
 
   /**
    * Creates an instance of Audio player.
@@ -98,6 +102,39 @@ export class AudioClass {
   }
 
   /**
+   * Recreates source and starts playback at specified time.
+   * @private
+   * @param {number} time - Time in seconds to start playback
+   * @param {AudioBuffer} buffer - The audio buffer to use
+   */
+  private recreateAndStart(time: number, buffer: AudioBuffer): void {
+    try {
+      initializeSource({
+        audioCtx: this._audioCtx,
+        volume: this._states.gainNode?.gain.value ?? this._initialVolume,
+        emitter: this._emitter,
+        states: this._states,
+      })
+
+      const { source } = this._states
+
+      if (source) {
+        source.buffer = buffer
+        source.loop = this._initialLoop
+
+        start(this._audioCtx, source, time)
+        this._startTime = this._audioCtx.currentTime
+        this._pauseTime = time
+        this._states.isPlaying = true
+        this._states.hasStarted = true
+      }
+    } catch (error) {
+      console.error('Failed to recreate audio source:', error)
+      this._states.isPlaying = false
+    }
+  }
+
+  /**
    * Fetches and decodes the audio buffer for the given source node.
    * @private
    * @param {AudioBufferSourceNode} source - The audio source node to load buffer into
@@ -128,6 +165,7 @@ export class AudioClass {
   public play(): void {
     if (this._states.hasStarted) {
       this._audioCtx.resume()
+      this._startTime = this._audioCtx.currentTime
       this._states.isPlaying = true
       return
     }
@@ -145,9 +183,13 @@ export class AudioClass {
       this.curryGetBuffer(source)
 
       if (this._states.isDecoded) {
-        start(this._audioCtx, source, this._initialTime)
+        start(this._audioCtx, source, this._pauseTime ?? this._initialTime)
+        this._startTime = this._audioCtx.currentTime
       } else {
-        this._emitter.listener('decoded', () => start(this._audioCtx, source, this._initialTime))
+        this._emitter.listener('decoded', () => {
+          start(this._audioCtx, source, this._pauseTime ?? this._initialTime)
+          this._startTime = this._audioCtx.currentTime
+        })
       }
 
       this._states.hasStarted = true
@@ -160,6 +202,10 @@ export class AudioClass {
    * Pauses audio playback by suspending the audio context.
    */
   public pause(): void {
+    if (this._states.isPlaying) {
+      this._pauseTime = this.currentTime
+    }
+
     this._audioCtx.suspend()
     this._states.isPlaying = false
   }
@@ -256,7 +302,48 @@ export class AudioClass {
    * @returns {number} The current playback position if available; otherwise, returns 0.
    */
   public get currentTime(): number {
-    return this._states.source?.context.currentTime ?? 0
+    if (!this._states.hasStarted) {
+      return 0
+    }
+
+    if (!this._states.isPlaying) {
+      return this._pauseTime
+    }
+
+    return this._pauseTime + (this._audioCtx.currentTime - this._startTime)
+  }
+
+  /**
+   * Seeks to a specific time position in the audio track.
+   * @param {number} time - Time in seconds to seek to (0 ≤ time ≤ duration)
+   */
+  public seek(time: number): void {
+    if (!this._states.source?.buffer || !this._states.isDecoded) {
+      return
+    }
+
+    // Clamp time to valid bounds
+    time = Math.max(0, Math.min(time, this.duration))
+
+    const wasPlaying = this._states.isPlaying
+    const audioBuffer = this._states.source.buffer
+
+    // Stop current source if playing
+    if (this._states.source && wasPlaying) {
+      try {
+        this._states.source.stop(0)
+      } catch (error) {
+        console.error('Error stopping audio source:', error)
+      }
+    }
+
+    if (wasPlaying) {
+      // Recreate source and start playing at new position
+      this.recreateAndStart(time, audioBuffer)
+    } else {
+      // Just update pause position for paused audio
+      this._pauseTime = time
+    }
   }
 }
 

--- a/src/audio/Audio.ts
+++ b/src/audio/Audio.ts
@@ -63,9 +63,9 @@ export class AudioClass {
   /** @private Event handler for managing event subscriptions */
   private _eventHandler: EventHandler
   /** @private Track when playback started for currentTime calculation */
-  private _startTime: number = 0
+  private _startTime = 0
   /** @private Track pause position for accurate seeking */
-  private _pauseTime: number = 0
+  private _pauseTime = 0
 
   /**
    * Creates an instance of Audio player.

--- a/src/audio/__tests__/Audio.test.ts
+++ b/src/audio/__tests__/Audio.test.ts
@@ -1,12 +1,55 @@
 import Audio from '../Audio'
-
-const audioCtxMock = {} as AudioContext
+import { AudioCtx } from '../AudioCtx'
 
 jest.mock('../AudioCtx', () => ({
-  AudioCtx: jest.fn().mockImplementation(() => audioCtxMock),
+  AudioCtx: jest.fn(),
+}))
+
+jest.mock('../initializeSource', () => ({
+  initializeSource: jest.fn(),
 }))
 
 describe('audio', () => {
+  let audioCtxMock: AudioContext
+  let mockCreateBufferSource: jest.Mock
+  let mockCreateGain: jest.Mock
+  let mockResume: jest.Mock
+  let mockSuspend: jest.Mock
+
+  beforeEach(() => {
+    // Create mock functions
+    mockCreateBufferSource = jest.fn()
+    mockCreateGain = jest.fn()
+    mockResume = jest.fn()
+    mockSuspend = jest.fn()
+
+    // Create mock AudioContext
+    audioCtxMock = {
+      createBufferSource: mockCreateBufferSource,
+      createGain: mockCreateGain,
+      resume: mockResume,
+      suspend: mockSuspend,
+      state: 'running',
+    } as unknown as AudioContext
+
+    // Set up the mock implementation
+    ;(AudioCtx as unknown as jest.Mock).mockImplementation(() => audioCtxMock)
+
+    // Reset mock implementations
+    mockCreateBufferSource.mockReturnValue({
+      buffer: null,
+      loop: false,
+      stop: jest.fn(),
+      start: jest.fn(),
+      context: audioCtxMock,
+    })
+
+    mockCreateGain.mockReturnValue({
+      gain: { value: 0.8 },
+      connect: jest.fn(),
+    })
+  })
+
   it('should audio object be defined', () => {
     expect(Audio).toBeDefined()
   })
@@ -15,5 +58,107 @@ describe('audio', () => {
     const audio = Audio({ file: 'test.mp3' })
     expect(audio.audioCtx).toBeDefined()
     expect(audio.audioCtx).toBe(audioCtxMock)
+  })
+
+  describe('seek method', () => {
+    let audio: ReturnType<typeof Audio>
+    let mockSource: AudioBufferSourceNode
+    let mockGainNode: GainNode
+
+    beforeEach(() => {
+      mockSource = {
+        buffer: null,
+        loop: false,
+        stop: jest.fn(),
+        start: jest.fn(),
+        context: audioCtxMock,
+      } as unknown as AudioBufferSourceNode
+
+      mockGainNode = {
+        gain: {
+          value: 0.8,
+        },
+        connect: jest.fn(),
+      } as unknown as GainNode
+
+      audio = Audio({ file: 'test.mp3' })
+    })
+
+    it('should seek to a valid time position', () => {
+      Object.defineProperty(audio, '_states', {
+        value: {
+          isDecoded: true,
+          isPlaying: false,
+          hasStarted: true,
+          source: mockSource,
+          gainNode: mockGainNode,
+        },
+        writable: true,
+      })
+
+      Object.defineProperty(audio, 'duration', {
+        get: () => 120,
+        configurable: true,
+      })
+
+      expect(() => audio.seek(60)).not.toThrow()
+    })
+
+    it('should clamp negative time to 0', () => {
+      mockSource.buffer = { duration: 120 } as AudioBuffer
+
+      Object.defineProperty(audio, '_states', {
+        value: {
+          isDecoded: true,
+          isPlaying: false,
+          hasStarted: true,
+          source: mockSource,
+          gainNode: mockGainNode,
+        },
+        writable: true,
+      })
+
+      expect(() => audio.seek(-10)).not.toThrow()
+      expect(audio['_pauseTime']).toBe(0)
+    })
+
+    it('should clamp time beyond duration to duration', () => {
+      mockSource.buffer = { duration: 120 } as AudioBuffer
+
+      Object.defineProperty(audio, '_states', {
+        value: {
+          isDecoded: true,
+          isPlaying: false,
+          hasStarted: true,
+          source: mockSource,
+          gainNode: mockGainNode,
+        },
+        writable: true,
+      })
+
+      expect(() => audio.seek(150)).not.toThrow()
+      expect(audio['_pauseTime']).toBe(120)
+    })
+
+    it('should seek to boundary values correctly', () => {
+      Object.defineProperty(audio, '_states', {
+        value: {
+          isDecoded: true,
+          isPlaying: false,
+          hasStarted: true,
+          source: mockSource,
+          gainNode: mockGainNode,
+        },
+        writable: true,
+      })
+
+      Object.defineProperty(audio, 'duration', {
+        get: () => 120,
+        configurable: true,
+      })
+
+      expect(() => audio.seek(0)).not.toThrow()
+      expect(() => audio.seek(130)).not.toThrow()
+    })
   })
 })


### PR DESCRIPTION
Adds seeking support and accurate time calculation for playback.

- Implement `seek(time)` to jump to a specific position
- Track `_startTime` and `_pauseTime` for precise timing
- Rework `currentTime` to return correct value when playing/paused
- Update `play()/pause()` to maintain timing state
- Add `recreateAndStart()` to resume from arbitrary positions